### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/deploy_awseb.yml
+++ b/.github/workflows/deploy_awseb.yml
@@ -26,7 +26,7 @@ jobs:
       id: get_version
       run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF#refs/*/v})
     - name: Publish to Github Packages Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: calitb/digitaloceanworkflow/portal
         registry: docker.pkg.github.com

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -26,7 +26,7 @@ jobs:
       id: get_version
       run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF#refs/*/v})
     - name: Publish to Github Packages Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: calitb/digitaloceanworkflow/portal
         registry: docker.pkg.github.com

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -24,7 +24,7 @@ jobs:
       env:
         CI: true
     - name: Publish to Github Packages Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: calitb/digitaloceanworkflow/portal
         registry: docker.pkg.github.com


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore